### PR TITLE
update google maps

### DIFF
--- a/front_end/src/index.css
+++ b/front_end/src/index.css
@@ -86,7 +86,7 @@ body {
 
 .map {
   width: 100%;
-  height: 92vh;
+  height: 56vh;
 }
 
 /*
@@ -111,6 +111,7 @@ body {
   .map {
     margin: 10px;
     width: 100%;
+    height: 92vh;
   }
 
   .list {


### PR DESCRIPTION
when screen is small size, Google maps will just occupy half of the screen.
![image](https://user-images.githubusercontent.com/95324013/198357234-b0d68fd5-cf01-4218-8dfd-744383fb4007.png)
